### PR TITLE
Add player stats command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project is a C++/Qt5 application that helps build balanced football teams a
 - **Balanced team suggestion** – when starting a new game, the app suggests a split of available players into two sides with the smallest possible rating difference. Virtual players may be added if an odd number attend.
 - **Rating history graph** – visualize rating progression per player across all games.
 - **Persistent storage** – data is kept in `pootjeover.db` so ratings and results remain between sessions.
+- **CLI player statistics** – compute per-player game results and goals from the database.
 
 ## Database schema
 


### PR DESCRIPTION
## Summary
- add `_compute_player_stats` helper and CLI subcommand `player-stats`
- display games played, results and goals per player
- document the new feature in the README

## Testing
- `python3 -m py_compile python_cli/main.py`
- `python3 python_cli/main.py player-stats --db pootjeover.db | head -n 5`
- `python3 python_cli/main.py player-stats --db pootjeover.db | tail -n 3`


------
https://chatgpt.com/codex/tasks/task_e_685c6b267d208331bdd2abccdd13e40c